### PR TITLE
Build on windows

### DIFF
--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -1,0 +1,55 @@
+# Build instructions for Windows
+
+## Prerequisites
+In order to compile json-c and matlab-json, you will need the following tools:
+
+* [Windows SDK 7.1][1] ([Mathworks instructions][3])
+* [Visual Studio 2013][2] (recommended to use Community edition)
+
+[1]: http://www.microsoft.com/en-us/download/details.aspx?id=8279
+[2]: http://www.visualstudio.com/
+[3]: http://uk.mathworks.com/matlabcentral/answers/101105-how-do-i-install-microsoft-windows-sdk-7-1
+
+## Code
+The `make` file for Windows assumes that the [json-c][4] source code is available
+in a directory called `json-c` within the same parent directory as the directory
+containing the [matlab-json][5] source code.
+
+A typical layout would be:
+
+* src/
+	* json-c/
+		* json.h
+		* ...
+	* matlab-json/
+		* make.m
+		* fromjson.c
+		* ...
+
+[4]: https://github.com/json-c/json-c
+[5]: https://github.com/christianpanton/matlab-json
+
+## Compile JSON-C
+* Open `json-c.vcxproj` file in Visual Studio 2013
+* Select "Debug" configuration
+* Select appropriate platform for the target MEX file (win32 => mexw32, x64 => mexw64)
+* In the project properties, set the following properties
+	* "Configuration Properties\General\Platform Toolset" = "Windows7.1SDK"
+* Check the following project properties:
+	* "Configuration Properties\General\Output Directory" = "$(SolutionDir)$(Configuration)\" (win32 only)
+	* "Configuration Properties\General\Output Directory" = "$(SolutionDir)$(Platform)\$(Configuration)\" (x64 only)
+	* "Configuration Properties\General\Target Name" = "$(ProjectName)"
+	* "Configuration Properties\General\Target Extension" = ".lib"
+	* "Configuration Properties\General\Configuration Type" = "Static Library"
+	* "Configuration Properties\C\C++\Advanced\CompileAs" = "Compile as C++ Code (/TP)"
+	* "Configuration Properties\C\C++\Code Generation\Runtime Library" = "Multi-threaded DLL (/MD)"
+	* "Configuration Properties\Librarian\General\Output File" = "$(OutDir)$(TargetName)$(TargetExt)"
+* Build the project
+
+The json-c library file `json-c.lib` should have been created in the location
+that is expected by the matlab-json `make` function.
+
+## Compile MATLAB-JSON
+* Open MATLAB and change to the matlab-json directory
+* Run `mex -setup`, if this hasn't been done before and you're using R2013b or earlier, and select "Microsoft Software Development Kit (SDK) 7.1"
+* Run `make`

--- a/fromjson.c
+++ b/fromjson.c
@@ -1,5 +1,5 @@
-#include <json/json.h>
-#include <json/json_object_private.h>
+#include <json.h>
+#include <json_object_private.h>
 #include <stdio.h>
 #include <string.h>
 #include "mex.h"

--- a/make.m
+++ b/make.m
@@ -1,12 +1,23 @@
-clear mex % avoid lock on file
+function make(varargin)
+
+mexargs = [{'-ljson-c', '-g'} varargin];
+
 if ispc
     % Windows7/Visual Studio 2010
-    mex -ljson -g LINKFLAGS="$LINKFLAGS /NODEFAULTLIB:MSVSRT.lib /NODEFAULTLIB:LIBCMT.lib" -IC:\Users\panton\code\ -LC:\Users\panton\code\json-c\Release\ fromjson.c
-    mex -ljson -g LINKFLAGS="$LINKFLAGS /NODEFAULTLIB:MSVSRT.lib /NODEFAULTLIB:LIBCMT.lib" -IC:\Users\panton\code\ -LC:\Users\panton\code\json-c\Release\ tojson.c 
+    
+    % Assume json-c and matlab-json are checked out in the same directory
+    json_c_path = fullfile(fileparts(pwd), 'json-c');
+    
+    mexargs = [{
+        ['-I' json_c_path], ['-L' fullfile(json_c_path, 'Release')], ...
+        'LINKFLAGS="$LINKFLAGS' '/NODEFAULTLIB:MSVSRT' '/NODEFAULTLIB:MSVCRTD' '/NODEFAULTLIB:LIBCMT"', ...
+        } mexargs];
+    mex(mexargs{:}, 'fromjson.c')
+    mex(mexargs{:}, 'tojson.c')
 else
     % Linux/Ubuntu/GCC
-    mex -ljson-c -g fromjson.c
-    mex -ljson-c -lm -g tojson.c
+    mex(mexargs{:}, 'fromjson.c')
+    mex(mexargs{:}, '-lm', 'tojson.c')
 end
 
 mex setjsonfield.c

--- a/make.m
+++ b/make.m
@@ -1,23 +1,33 @@
 function make(varargin)
 
-mexargs = [{'-ljson-c', '-g'} varargin];
+mexargs_common = [{'-g'} varargin];
+mexargs_json = [mexargs_common {'-ljson-c'}];
 
 if ispc
     % Windows7/Visual Studio 2010
     
     % Assume json-c and matlab-json are checked out in the same directory
     json_c_path = fullfile(fileparts(pwd), 'json-c');
+    json_lib_path = json_c_path;
+    if strcmp(computer('arch'), 'win64')
+        json_lib_path = fullfile(json_lib_path, 'x64');
+    end
+    if any(strcmp(mexargs_json, '-g'))
+        json_lib_path = fullfile(json_lib_path, 'Debug');
+    else
+        json_lib_path = fullfile(json_lib_path, 'Release');
+    end
     
-    mexargs = [{
-        ['-I' json_c_path], ['-L' fullfile(json_c_path, 'Release')], ...
-        'LINKFLAGS="$LINKFLAGS' '/NODEFAULTLIB:MSVSRT' '/NODEFAULTLIB:MSVCRTD' '/NODEFAULTLIB:LIBCMT"', ...
-        } mexargs];
-    mex(mexargs{:}, 'fromjson.c')
-    mex(mexargs{:}, 'tojson.c')
+    mexargs_json = [{
+        ['-I' json_c_path], ['-L' json_lib_path], ...
+        ... % 'LINKFLAGS="$LINKFLAGS' '/NODEFAULTLIB:MSVSRT' '/NODEFAULTLIB:MSVCRTD' '/NODEFAULTLIB:LIBCMT' '/NODEFAULTLIB:LIBCMTD"', ...
+        } mexargs_json];
+    mex(mexargs_json{:}, 'fromjson.c')
+    mex(mexargs_json{:}, 'tojson.c')
 else
     % Linux/Ubuntu/GCC
-    mex(mexargs{:}, 'fromjson.c')
-    mex(mexargs{:}, '-lm', 'tojson.c')
+    mex(mexargs_json{:}, 'fromjson.c')
+    mex(mexargs_json{:}, '-lm', 'tojson.c')
 end
 
-mex setjsonfield.c
+mex(mexargs_common{:}, 'setjsonfield.c')

--- a/tojson.c
+++ b/tojson.c
@@ -1,4 +1,4 @@
-#include <json/json.h>
+#include <json.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>


### PR DESCRIPTION
Added smarter `make` file and detailed build instructions for Windows.

Works with my modifications to json-c: https://github.com/Nzbuu/json-c/tree/fix-win32-build-problems