### PR TITLE
Fix encoding of Unicode strings

### DIFF
--- a/tojson.c
+++ b/tojson.c
@@ -85,8 +85,7 @@ void parse(mxArray *ma, json_object **jo){
 
     /* was char - convert to string*/
     if(mxIsChar(ma)){
-        char *str = mxMalloc((num_el + 1)*sizeof(char*));
-        mxGetString(ma, str, num_el + 1);
+        char *str = mxArrayToString(ma);
         *jo = json_object_new_string(str);
     }
     /* was struct - convert to object */


### PR DESCRIPTION
Unicode strings were not encoded properly because buffer size > (num_el + 1) * sizeof(char*)
To check:
tojson(char(1200))
Should now result in:
"Ұ"
Instead of:
"�"
