### PR TITLE
Fix crashes in tojson

### DIFF
--- a/make.m
+++ b/make.m
@@ -1,6 +1,7 @@
 function make(varargin)
 
-mexargs_common = [{'-g'} varargin];
+% mexargs_common = [{'-g'} varargin];
+mexargs_common = [ varargin];
 mexargs_json = [mexargs_common {'-ljson-c'}];
 
 if ispc

--- a/make.m
+++ b/make.m
@@ -1,7 +1,6 @@
 function make(varargin)
 
-% mexargs_common = [{'-g'} varargin];
-mexargs_common = [ varargin];
+mexargs_common = [{'-g'} varargin];
 mexargs_json = [mexargs_common {'-ljson-c'}];
 
 if ispc

--- a/tojson.c
+++ b/tojson.c
@@ -67,12 +67,16 @@ void object(mxArray *ma, int i, json_object **jo){
 
     for(; j < n; j++){
         tmpma = mxGetFieldByNumber(ma, i, j);
+        bool needDestroy = false;
         if (tmpma == NULL){
             /* Object is NULL, create an empty matrix instead */
             tmpma = mxCreateNumericMatrix(0, 0, mxDOUBLE_CLASS, mxREAL);
+            needDestroy = true;
         }
         parse(tmpma, &tmpobj);
         json_object_object_add(*jo, mxGetFieldNameByNumber(ma, j), tmpobj);
+        if (needDestroy)
+            mxDestroyArray(tmpma);
     }
 }
 

--- a/tojson.c
+++ b/tojson.c
@@ -67,6 +67,10 @@ void object(mxArray *ma, int i, json_object **jo){
 
     for(; j < n; j++){
         tmpma = mxGetFieldByNumber(ma, i, j);
+        if (tmpma == NULL){
+            /* Object is NULL, create an empty matrix instead */
+            tmpma = mxCreateNumericMatrix(0, 0, mxDOUBLE_CLASS, mxREAL);
+        }
         parse(tmpma, &tmpobj);
         json_object_object_add(*jo, mxGetFieldNameByNumber(ma, j), tmpobj);
     }


### PR DESCRIPTION
Empty fields in struct arrays will be null if they were automatically created by an assignment which adds a new field to the struct array. This caused tojson to crash. 

To reproduce:
a(2).b = 1;
tojson(a)