### PR TITLE
Remove unnecessary #include

### DIFF
--- a/fromjson.c
+++ b/fromjson.c
@@ -1,9 +1,7 @@
 #ifdef JSON_C_DIR_PREFIXED
     #include <json-c/json.h>
-    #include <json-c/json_object_private.h>
 #else
     #include <json.h>
-    #include <json_object_private.h>
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
This `#include` directive caused issues in versions of `json-c` newer than 0.11 where this header file no longer exists. It turns out that it is not necessary in version 0.11 either, so this change makes this library compatible with all versions of `json-c` >= 0.11.